### PR TITLE
[STOR-539]Allow to label consumergroup_lag and consumergroup_lag_sum metrics by…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ language: go
 go:
 - 1.14
 
-after_success:
-- if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  make docker;
-  make push;
-  fi
 - if [[ -n "$TRAVIS_TAG" ]]; then
   make crossbuild release;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ language: go
 go:
 - 1.14
 
+after_success:
 - if [[ -n "$TRAVIS_TAG" ]]; then
   make crossbuild release;
   fi

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ pkgs   = $(shell $(GO) list ./... | grep -v /vendor/)
 
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
-DOCKER_IMAGE_NAME       ?= kafka-exporter
-DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 TAG 					:= $(shell echo `if [ "$(TRAVIS_BRANCH)" = "master" ] || [ "$(TRAVIS_BRANCH)" = "" ] ; then echo "latest"; else echo $(TRAVIS_BRANCH) ; fi`)
 
 all: format build test
@@ -38,16 +36,6 @@ tarball: promu
 	@echo ">> building release tarball"
 	@$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
 
-docker:
-	@echo ">> building docker image"
-	@docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
-
-push:
-	@echo ">> pushing docker image, $(DOCKER_USERNAME),$(DOCKER_IMAGE_NAME),$(TAG)"
-	@docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
-	@docker tag "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" "$(DOCKER_USERNAME)/$(DOCKER_IMAGE_NAME):$(TAG)"
-	@docker push "$(DOCKER_USERNAME)/$(DOCKER_IMAGE_NAME):$(TAG)"
-
 release: promu github-release
 	@echo ">> pushing binary to github with ghr"
 	@$(PROMU) crossbuild tarballs
@@ -63,4 +51,4 @@ github-release:
 		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
 		$(GO) get -u github.com/aktau/github-release
 
-.PHONY: all style format build test vet tarball docker promu
+.PHONY: all style format build test vet tarball promu

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ kafka_consumergroup_lag{consumergroup="KMOffsetCache-kafka-manager-3806276532-ml
 ```
 
 ### Custom tagging consumergroup lag metrics
+
 ConsumerGroup lag metrics can be tagged with `owner:$WHATEVER` when ENV `CONSUMERGROUP_LAG_CUSTOM_LABELS` is set.
 
 For example if I want to tag my consumergroups lag metrcis which start with `my-cool-consuemrgroup-xxxxxxxxxxxx` (consumer group names) with  `owner:myCoolTeam`

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ kafka_consumergroup_lag{consumergroup="KMOffsetCache-kafka-manager-3806276532-ml
 
 ConsumerGroup lag metrics can be tagged with `owner:$WHATEVER` when ENV `CONSUMERGROUP_LAG_CUSTOM_LABELS` is set.
 
-For example if I want to tag my consumergroups lag metrcis which start with `my-cool-consuemrgroup-xxxxxxxxxxxx` (consumer group names) with  `owner:myCoolTeam`
+As an example to tag my consumer group lag metrics which start with `my-cool-consumergroup-xxxxxxxxxxxx` (consumer group names) with  `owner:myCoolTeam`
 then I set the ENV like this:
 `{"consumer_notifiers": [{"when":{"starts_with":["my-cool"]}, "set": { "tags":["owner:myCoolTeam"]}}]}`
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Table of Contents
 	-	[Brokers](#brokers)
 	-	[Topics](#topics)
 	-	[Consumer Groups](#consumer-groups)
+	-	[Custom tagging consumergroup lag metrics](#consumergroup-custom-tagging)
 -	[Grafana Dashboard](#grafana-dashboard)	
 -   [Contribute](#contribute)
 -   [Donation](#donation)
@@ -213,6 +214,16 @@ kafka_consumergroup_current_offset{consumergroup="KMOffsetCache-kafka-manager-38
 # TYPE kafka_consumergroup_lag gauge
 kafka_consumergroup_lag{consumergroup="KMOffsetCache-kafka-manager-3806276532-ml44w",partition="0",topic="__consumer_offsets"} 1
 ```
+
+### Custom tagging consumergroup lag metrics
+ConsumerGroup lag metrics can be tagged with `owner:$WHATEVER` when ENV `CONSUMERGROUP_LAG_CUSTOM_LABELS` is set.
+
+For example if I want to tag my consumergroups lag metrcis which start with `my-cool-consuemrgroup-xxxxxxxxxxxx` (consumer group names) with  `owner:myCoolTeam`
+then I set the ENV like this:
+`{"consumer_notifiers": [{"when":{"starts_with":["my-cool"]}, "set": { "tags":["owner:myCoolTeam"]}}]}`
+
+Custom tagging will be skipped when the `CONSUMERGROUP_LAG_CUSTOM_LABELS` format is wrong.
+
 
 Grafana Dashboard
 -------

--- a/customLabels.go
+++ b/customLabels.go
@@ -23,7 +23,7 @@ func NewCustomCGLagLabels(config string, CacheExpirationInMin, CachecleanupInter
 	labelByOwner := make(map[string][]string)
 	err := json.Unmarshal([]byte(config), &labelByOwner)
 	if err != nil {
-		plog.Debugf("Error unmarshalling Json string:", err)		
+		plog.Debugln("Error unmarshalling Json string:", err)		
 		return nil, err
 	}
 
@@ -50,7 +50,7 @@ func NewCustomCGLagLabels(config string, CacheExpirationInMin, CachecleanupInter
 func (c *CustomCGLagLabels) FetchLabel(groupId string) string {
 	owner, found := c.labelCache.Get(groupId)
 	if found {
-		plog.Debugf("Cache hit for consumergroup:", groupId)
+		plog.Debugln("Cache hit for consumergroup:", groupId)
 		c.labelCache.Set(groupId, owner, c.cacheExpirationInMin) // Let's renew TTL to keep a "kind"" of LRU
 		return owner.(string)
 	} else {

--- a/customLabels.go
+++ b/customLabels.go
@@ -16,11 +16,13 @@ type CustomCGLagLabels struct {
 	cachecleanupIntervalinMin			time.Duration
 }
 
+type Notifier map[string]map[string][]string
+
 func NewCustomCGLagLabels(config string, CacheExpirationInMin, CachecleanupIntervalinMin time.Duration) (*CustomCGLagLabels, error){
 	cacheExpirationInMin := CacheExpirationInMin*time.Minute
 	cachecleanupIntervalinMin := CachecleanupIntervalinMin*time.Minute
+	consumerNotifiers := make(map[string][]Notifier)
 
-	consumerNotifiers := make(map[string][]map[string]map[string][]string)
 	err := json.Unmarshal([]byte(config), &consumerNotifiers)
 	if err != nil {
 		plog.Debugln("Error unmarshalling Json string:", err)		

--- a/customLabels.go
+++ b/customLabels.go
@@ -65,14 +65,12 @@ type CustomCGLagLabels struct {
 	labelByPrefix					map[string]string
 	labelCache					*go_cache.Cache
 	cacheExpirationInMin				time.Duration
-	cachecleanupIntervalinMin			time.Duration
+	cacheCleanupIntervalInMin			time.Duration
 }
 
 type Notifier map[string]map[string][]string
 
-func NewCustomCGLagLabels(config string, CacheExpirationInMin, CachecleanupIntervalinMin time.Duration) (*CustomCGLagLabels, error){
-	cacheExpirationInMin := CacheExpirationInMin*time.Minute
-	cachecleanupIntervalinMin := CachecleanupIntervalinMin*time.Minute
+func NewCustomCGLagLabels(config string, cacheExpirationInMin, cacheCleanupIntervalInMin time.Duration) (*CustomCGLagLabels, error){
 	consumerNotifiers := make(map[string][]Notifier)
 	schemaLoader := gojsonschema.NewStringLoader(SCHEMA)
 	documentLoader := gojsonschema.NewStringLoader(config)
@@ -120,12 +118,12 @@ func NewCustomCGLagLabels(config string, CacheExpirationInMin, CachecleanupInter
 	}
 
 	// Create cache
-	labelCache := go_cache.New(cacheExpirationInMin, cachecleanupIntervalinMin)
+	labelCache := go_cache.New(cacheExpirationInMin*time.Minute, cacheCleanupIntervalInMin*time.Minute)
 	return &CustomCGLagLabels{
 		labelByPrefix: labelByPrefix,
 		labelCache: labelCache,
-		cacheExpirationInMin: cacheExpirationInMin,
-		cachecleanupIntervalinMin: cachecleanupIntervalinMin,
+		cacheExpirationInMin: cacheExpirationInMin*time.Minute,
+		cacheCleanupIntervalInMin: cacheCleanupIntervalInMin*time.Minute,
 	}, nil
 }
 

--- a/customLabels.go
+++ b/customLabels.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	go_cache "github.com/patrickmn/go-cache"
+	"strings"
+	"time"
+	plog "github.com/prometheus/common/log"
+)
+
+// Custom labels for ConsumerGroups
+type CustomCGLagLabels struct {
+	labelByPrefix			map[string]string
+	labelCache			*go_cache.Cache
+}
+
+func NewCustomCGLagLabels(config string) (*CustomCGLagLabels, error){
+	labelByOwner := make(map[string][]string)
+	err := json.Unmarshal([]byte(config), &labelByOwner)
+	if err != nil {
+		return nil, err
+	}
+
+	labelByPrefix := make(map[string]string)
+	for owner, startWith := range  labelByOwner{
+		for _, startWith := range startWith {
+			labelByPrefix[startWith] = owner
+		}
+	}
+	labelCache := go_cache.New(1440*time.Minute, 60*time.Minute)
+	return &CustomCGLagLabels{labelByPrefix: labelByPrefix, labelCache: labelCache}, nil
+}
+
+func (c *CustomCGLagLabels) FetchLabel(groupId string) string {
+	var owner, found = c.labelCache.Get(groupId)
+	if found {
+		plog.Debugf("Cache hit for consumergroup: \"%s\"", groupId)
+		return owner.(string)
+	} else {
+		for startWith, owner := range c.labelByPrefix {
+        		if strings.HasPrefix(groupId, startWith) {
+				c.labelCache.Set(groupId, owner, 1440*time.Minute)
+            			return owner
+         		}
+     		}
+		return ""
+	}
+}

--- a/customLabels.go
+++ b/customLabels.go
@@ -23,13 +23,14 @@ func NewCustomCGLagLabels(config string, CacheExpirationInMin, CachecleanupInter
 	labelByOwner := make(map[string][]string)
 	err := json.Unmarshal([]byte(config), &labelByOwner)
 	if err != nil {
+		plog.Debugf("Error unmarshalling Json string: %v", err)		
 		return nil, err
 	}
 
 	labelByPrefix := make(map[string]string)
 	for owner, startWith := range  labelByOwner{
 		for _, startWith := range startWith {
-			// If key already exist we Warn and skip the overwrite
+			// If key already exists then warn and skip the overwrite
 			if _, ok := labelByPrefix[startWith]; ok {
 				plog.Warnln("startWith key %s was set twice, skipping latest occurrence", startWith)
 				continue
@@ -47,7 +48,7 @@ func NewCustomCGLagLabels(config string, CacheExpirationInMin, CachecleanupInter
 }
 
 func (c *CustomCGLagLabels) FetchLabel(groupId string) string {
-	var owner, found = c.labelCache.Get(groupId)
+	owner, found := c.labelCache.Get(groupId)
 	if found {
 		plog.Debugf("Cache hit for consumergroup: \"%s\"", groupId)
 		c.labelCache.Set(groupId, owner, c.cacheExpirationInMin) // Let's renew TTL to keep a "kind"" of LRU

--- a/customLabels.go
+++ b/customLabels.go
@@ -23,7 +23,7 @@ func NewCustomCGLagLabels(config string, CacheExpirationInMin, CachecleanupInter
 	labelByOwner := make(map[string][]string)
 	err := json.Unmarshal([]byte(config), &labelByOwner)
 	if err != nil {
-		plog.Debugf("Error unmarshalling Json string: %v", err)		
+		plog.Debugf("Error unmarshalling Json string:", err)		
 		return nil, err
 	}
 
@@ -32,7 +32,7 @@ func NewCustomCGLagLabels(config string, CacheExpirationInMin, CachecleanupInter
 		for _, startWith := range startWith {
 			// If key already exists then warn and skip the overwrite
 			if _, ok := labelByPrefix[startWith]; ok {
-				plog.Warnln("startWith key %s was set twice, skipping latest occurrence", startWith)
+				plog.Warnln("startWith key", startWith, "was set twice, skipping latest occurrence")
 				continue
 			}
 			labelByPrefix[startWith] = owner
@@ -50,7 +50,7 @@ func NewCustomCGLagLabels(config string, CacheExpirationInMin, CachecleanupInter
 func (c *CustomCGLagLabels) FetchLabel(groupId string) string {
 	owner, found := c.labelCache.Get(groupId)
 	if found {
-		plog.Debugf("Cache hit for consumergroup: \"%s\"", groupId)
+		plog.Debugf("Cache hit for consumergroup:", groupId)
 		c.labelCache.Set(groupId, owner, c.cacheExpirationInMin) // Let's renew TTL to keep a "kind"" of LRU
 		return owner.(string)
 	} else {

--- a/customLabels_test.go
+++ b/customLabels_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+	"os"
+	"github.com/stretchr/testify/assert"
+)
+
+
+
+const (
+	INCORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS = `{"team1": [["start-string1"], "team2": []}`
+	CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS = `{"team1": ["st-string1", "start-string2"], "team2": ["this-start-string3"]}`
+)
+
+func TestNewCustomCGLagLabels_wrong_config(t *testing.T){
+	os.Setenv("CONSUMERGROUP_LAG_CUSTOM_LABELS", INCORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS)
+	customLabelsEnv, _ := os.LookupEnv("CONSUMERGROUP_LAG_CUSTOM_LABELS")
+	_, err := NewCustomCGLagLabels(customLabelsEnv)
+
+	if err == nil {
+		t.Errorf("Json string should have failed due to the wrong string json format")
+	}
+}
+
+func TestNewCustomCGLagLabels_correct_config(t *testing.T){
+	os.Setenv("CONSUMERGROUP_LAG_CUSTOM_LABELS", CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS)
+	customLabelsEnv, _ := os.LookupEnv("CONSUMERGROUP_LAG_CUSTOM_LABELS")
+	customLabels, err := NewCustomCGLagLabels(customLabelsEnv)
+
+	// Assert No errors from json string to map
+	if err != nil {
+		t.Errorf("Json string should have not failed due to the correct string json format")
+	}
+
+	// Assert labelByPrefix are correct
+	assert.Equal(t, customLabels.labelByPrefix["st-string1"], "team1")
+	assert.Equal(t, customLabels.labelByPrefix["this-start-string3"], "team2")
+}
+
+func TestFetchLabel_success(t *testing.T){
+	os.Setenv("CONSUMERGROUP_LAG_CUSTOM_LABELS", CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS)
+	customLabelsEnv, _ := os.LookupEnv("CONSUMERGROUP_LAG_CUSTOM_LABELS")
+	customLabels, _ := NewCustomCGLagLabels(customLabelsEnv)
+
+	// Value should not be in Cache, then Fetch it, and finally check the value is cached
+	_, found := customLabels.labelCache.Get("st-string1-consumergroup-name")
+	assert.Equal(t, found, false)
+	assert.Equal(t, customLabels.FetchLabel("st-string1-consumergroup-name"), "team1")
+	_, found = customLabels.labelCache.Get("st-string1-consumergroup-name")
+	assert.Equal(t, found, true)
+
+}
+

--- a/customLabels_test.go
+++ b/customLabels_test.go
@@ -46,7 +46,7 @@ func TestNewCustomCGLagLabels_wrong_config(t *testing.T){
 	_, err := NewCustomCGLagLabels(INCORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS, 1, 1)
 
 	if err == nil {
-		t.Errorf("Json string should have failed due to the wrong string json format")
+		assert.Error(t, err, "Json string should have failed due to the wrong string json format")
 	}
 }
 
@@ -55,7 +55,7 @@ func TestNewCustomCGLagLabels_correct_config(t *testing.T){
 
 	// Assert No errors from json string to map
 	if err != nil {
-		t.Errorf("Json string should have not failed due to the correct string json format")
+		assert.NoError(t, err, "Json string should have not failed due to the correct string json format")
 	}
 
 	// Assert labelByPrefix are correct

--- a/customLabels_test.go
+++ b/customLabels_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"testing"
-	"os"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,9 +13,7 @@ const (
 )
 
 func TestNewCustomCGLagLabels_wrong_config(t *testing.T){
-	os.Setenv("CONSUMERGROUP_LAG_CUSTOM_LABELS", INCORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS)
-	customLabelsEnv, _ := os.LookupEnv("CONSUMERGROUP_LAG_CUSTOM_LABELS")
-	_, err := NewCustomCGLagLabels(customLabelsEnv)
+	_, err := NewCustomCGLagLabels(INCORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS, 1, 1)
 
 	if err == nil {
 		t.Errorf("Json string should have failed due to the wrong string json format")
@@ -24,9 +21,7 @@ func TestNewCustomCGLagLabels_wrong_config(t *testing.T){
 }
 
 func TestNewCustomCGLagLabels_correct_config(t *testing.T){
-	os.Setenv("CONSUMERGROUP_LAG_CUSTOM_LABELS", CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS)
-	customLabelsEnv, _ := os.LookupEnv("CONSUMERGROUP_LAG_CUSTOM_LABELS")
-	customLabels, err := NewCustomCGLagLabels(customLabelsEnv)
+	customLabels, err := NewCustomCGLagLabels(CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS, 1, 1)
 
 	// Assert No errors from json string to map
 	if err != nil {
@@ -39,9 +34,7 @@ func TestNewCustomCGLagLabels_correct_config(t *testing.T){
 }
 
 func TestFetchLabel_success(t *testing.T){
-	os.Setenv("CONSUMERGROUP_LAG_CUSTOM_LABELS", CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS)
-	customLabelsEnv, _ := os.LookupEnv("CONSUMERGROUP_LAG_CUSTOM_LABELS")
-	customLabels, _ := NewCustomCGLagLabels(customLabelsEnv)
+	customLabels, _ := NewCustomCGLagLabels(CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS, 1, 1)
 
 	// Value should not be in Cache, then Fetch it, and finally check the value is cached
 	_, found := customLabels.labelCache.Get("st-string1-consumergroup-name")

--- a/customLabels_test.go
+++ b/customLabels_test.go
@@ -8,8 +8,38 @@ import (
 
 
 const (
-	INCORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS = `{"team1": [["start-string1"], "team2": []}`
-	CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS = `{"team1": ["st-string1", "start-string2"], "team2": ["this-start-string3"]}`
+	INCORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS = `{"consumer_notifiers": [[{"when":{ "starts_with":["string1", "string2"]}, "set": {"tags":["owner:fotocasa"]}}]}`
+	CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS = `{
+		"consumer_notifiers": [
+			{
+				"when": {
+					"start_with": [
+						"string1",
+						"string2"
+					]
+				},
+				"set": {
+					"tags":[
+						"owner:fotocasa"
+					]
+				}
+			},
+			{
+				"when": {
+					"start_with": [
+						"string3",
+						"string4"
+					]
+				},
+				"set": {
+					"tags":[
+						"owner:mads"
+					]
+				}
+
+			}
+		]
+	}`
 )
 
 func TestNewCustomCGLagLabels_wrong_config(t *testing.T){
@@ -29,18 +59,18 @@ func TestNewCustomCGLagLabels_correct_config(t *testing.T){
 	}
 
 	// Assert labelByPrefix are correct
-	assert.Equal(t, customLabels.labelByPrefix["st-string1"], "team1")
-	assert.Equal(t, customLabels.labelByPrefix["this-start-string3"], "team2")
+	assert.Equal(t, customLabels.labelByPrefix["string1"], "fotocasa")
+	assert.Equal(t, customLabels.labelByPrefix["string3"], "mads")
 }
 
 func TestFetchLabel_success(t *testing.T){
 	customLabels, _ := NewCustomCGLagLabels(CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS, 1, 1)
 
 	// Value should not be in Cache, then Fetch it, and finally check the value is cached
-	_, found := customLabels.labelCache.Get("st-string1-consumergroup-name")
+	_, found := customLabels.labelCache.Get("string1")
 	assert.Equal(t, found, false)
-	assert.Equal(t, customLabels.FetchLabel("st-string1-consumergroup-name"), "team1")
-	_, found = customLabels.labelCache.Get("st-string1-consumergroup-name")
+	assert.Equal(t, customLabels.FetchLabel("string1"), "fotocasa")
+	_, found = customLabels.labelCache.Get("string1")
 	assert.Equal(t, found, true)
 
 }

--- a/customLabels_test.go
+++ b/customLabels_test.go
@@ -13,7 +13,7 @@ const (
 		"consumer_notifiers": [
 			{
 				"when": {
-					"start_with": [
+					"starts_with": [
 						"string1",
 						"string2"
 					]
@@ -26,7 +26,7 @@ const (
 			},
 			{
 				"when": {
-					"start_with": [
+					"starts_with": [
 						"string3",
 						"string4"
 					]

--- a/customLabels_test.go
+++ b/customLabels_test.go
@@ -45,18 +45,14 @@ const (
 func TestNewCustomCGLagLabels_wrong_config(t *testing.T){
 	_, err := NewCustomCGLagLabels(INCORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS, 1, 1)
 
-	if err == nil {
-		assert.Error(t, err, "Json string should have failed due to the wrong string json format")
-	}
+	assert.Error(t, err, "Json string should have failed due to the wrong string json format")
 }
 
 func TestNewCustomCGLagLabels_correct_config(t *testing.T){
 	customLabels, err := NewCustomCGLagLabels(CORRECT_CONSUMERGROUP_LAG_CUSTOM_LABELS, 1, 1)
 
 	// Assert No errors from json string to map
-	if err != nil {
-		assert.NoError(t, err, "Json string should have not failed due to the correct string json format")
-	}
+	assert.NoError(t, err, "Json string should have not failed due to the correct string json format")
 
 	// Assert labelByPrefix are correct
 	assert.Equal(t, customLabels.labelByPrefix["string1"], "fotocasa")

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -488,7 +488,7 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 					if topicConsumed {
 						var currentOffsetSum int64
 						var lagSum int64
-						var ownerLabel = SetOwnerLabel(group.GroupId)
+						ownerLabel := SetOwnerLabel(group.GroupId)
 						for partition, offsetFetchResponseBlock := range partitions {
 							err := offsetFetchResponseBlock.Err
 							if err != sarama.ErrNoError {
@@ -692,7 +692,11 @@ func main() {
 	customLabelsEnv, isSet := os.LookupEnv("CONSUMERGROUP_LAG_CUSTOM_LABELS")
 	if isSet{
 		plog.Infoln("Env CONSUMERGROUP_LAG_CUSTOM_LABELS is set, loding custom owner label for consumergroups")
-		customLabels, _ = NewCustomCGLagLabels(customLabelsEnv)
+		var err error
+		customLabels, err = NewCustomCGLagLabels(customLabelsEnv, 1440, 60)
+		if err != nil{
+			plog.Errorln("Error initialazing CustomCGLagLabels structure, skipping labeling consumergroup lag metrics: ")
+		}
 	}
 
 	if *logSarama {

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -691,11 +691,11 @@ func main() {
 
 	customLabelsEnv, isSet := os.LookupEnv("CONSUMERGROUP_LAG_CUSTOM_LABELS")
 	if isSet{
-		plog.Infoln("Env CONSUMERGROUP_LAG_CUSTOM_LABELS is set, loding custom owner label for consumergroups")
+		plog.Infoln("Env CONSUMERGROUP_LAG_CUSTOM_LABELS is set, loading custom owner label for consumergroups")
 		var err error
 		customLabels, err = NewCustomCGLagLabels(customLabelsEnv, 1440, 60)
 		if err != nil{
-			plog.Errorln("Error initialazing CustomCGLagLabels structure, skipping labeling consumergroup lag metrics: ")
+			plog.Warnln("Error initialazing CustomCGLagLabels structure, skipping labeling consumergroup lag metrics: %v", err)
 		}
 	}
 

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -46,6 +47,45 @@ var (
 	consumergroupLagZookeeper          *prometheus.Desc
 	consumergroupMembers               *prometheus.Desc
 )
+
+// Convert the ENV json string in a map
+func getOwnerLabelMap() (map[string]string, bool) {
+	configMap := make(map[string][]string)
+	configMapByStartWith := make(map[string]string)
+
+	configString, isSet := os.LookupEnv("CONSUMERGROUP_LAG_CUSTOM_LABELS")
+	if isSet == false{
+		return configMapByStartWith, false
+	}
+
+	err := json.Unmarshal([]byte(configString), &configMap)
+	if err != nil {
+		plog.Warnln("Can not parse string from ENV CONSUMERGROUP_LAG_CUSTOM_LABELS, skipping setting owner label")
+		return configMapByStartWith, false
+	}
+
+	// We have owner as key and list of "start with" as values, we need to revert it
+	// for a more efficient lookup later on
+	for owner, startWithList := range configMap {
+		for _, startWith := range startWithList {
+			configMapByStartWith[startWith] = owner
+		}
+	}
+	return configMapByStartWith, true
+}
+
+// Finds the desired owner label when the groupId starts with a map key
+// It will returns in the first match
+func getConsumerGroupLagOwnerLabel(groupId string,  configMapByStartWith map[string]string) (string, bool){
+	for startWith, owner := range configMapByStartWith {
+		if strings.HasPrefix(groupId, startWith) {
+			return owner, true
+		}
+	}
+	return "", false
+}
+
+
 
 // Exporter collects Kafka stats from the given server and exports them using
 // the prometheus metrics package.
@@ -487,6 +527,8 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 					if topicConsumed {
 						var currentOffsetSum int64
 						var lagSum int64
+						var configMapByStartWith, _ = getOwnerLabelMap()
+						var ownerLabel, _ = getConsumerGroupLagOwnerLabel(group.GroupId, configMapByStartWith)
 						for partition, offsetFetchResponseBlock := range partitions {
 							err := offsetFetchResponseBlock.Err
 							if err != sarama.ErrNoError {
@@ -510,7 +552,7 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 									lagSum += lag
 								}
 								ch <- prometheus.MustNewConstMetric(
-									consumergroupLag, prometheus.GaugeValue, float64(lag), group.GroupId, topic, strconv.FormatInt(int64(partition), 10),
+									consumergroupLag, prometheus.GaugeValue, float64(lag), group.GroupId, topic, strconv.FormatInt(int64(partition), 10), ownerLabel,
 								)
 							} else {
 								plog.Errorf("No offset of topic %s partition %d, cannot get consumer group lag", topic, partition)
@@ -521,7 +563,7 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) {
 							consumergroupCurrentOffsetSum, prometheus.GaugeValue, float64(currentOffsetSum), group.GroupId, topic,
 						)
 						ch <- prometheus.MustNewConstMetric(
-							consumergroupLagSum, prometheus.GaugeValue, float64(lagSum), group.GroupId, topic,
+							consumergroupLagSum, prometheus.GaugeValue, float64(lagSum), group.GroupId, topic, ownerLabel,
 						)
 					}
 				}
@@ -659,7 +701,7 @@ func main() {
 	consumergroupLag = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "consumergroup", "lag"),
 		"Current Approximate Lag of a ConsumerGroup at Topic/Partition",
-		[]string{"consumergroup", "topic", "partition"}, labels,
+		[]string{"consumergroup", "topic", "partition", "owner"}, labels,
 	)
 
 	consumergroupLagZookeeper = prometheus.NewDesc(
@@ -671,7 +713,7 @@ func main() {
 	consumergroupLagSum = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "consumergroup", "lag_sum"),
 		"Current Approximate Lag of a ConsumerGroup at Topic for all partitions",
-		[]string{"consumergroup", "topic"}, labels,
+		[]string{"consumergroup", "topic", "owner"}, labels,
 	)
 
 	consumergroupMembers = prometheus.NewDesc(

--- a/kafka_exporter.go
+++ b/kafka_exporter.go
@@ -695,7 +695,7 @@ func main() {
 		var err error
 		customLabels, err = NewCustomCGLagLabels(customLabelsEnv, 1440, 60)
 		if err != nil{
-			plog.Warnln("Error initialazing CustomCGLagLabels structure, skipping labeling consumergroup lag metrics: %v", err)
+			plog.Warnln("Error initialazing CustomCGLagLabels structure, skipping labeling consumergroup lag metrics:", err)
 		}
 	}
 


### PR DESCRIPTION
… owner

## Summary
This PR aims to allow clients to TAG consumergroup_lag and consumergroup_lag_sum metrics.

* Improving the kafka_Exporter code
* Adding "first" unit tests for the customLabels code (avoid keep adding tech debt)
* Adding cache logic for keeping cosumergroups names--> owner tags in
memory
* Removing Docker upload inherited from the original kafka_exporter repo

Limitations:
* In order to do so CONSUMERGROUP_LAG_CUSTOM_LABELS environment variable must exist.
* The format expected is a dictionary , if the json schema is incorrect the owner tagging will be skipped (warning message on starting)
* If repeated "startWith" are present with different owners the first match will be the chosen one.
This happens because we want to be efficient in the hash lookup so we create a hash with all the startWith as key and the owner as values.


Test:
I ran it in a DEV cluster with real metrics, we can see in the logs the correct load when the ENV is set:
`{"level":"info","msg":"Env CONSUMERGROUP_LAG_CUSTOM_LABELS is set, loading custom owner label for consumergroups","source":"kafka_exporter.go:726","time":"2020-11-24T07:18:26Z"}`


We have set for start_with="p10n-" the owner:testp10 and for  start_with="related" the owner: testrelated
```
$ curl localhost:9308/metrics|grep lag|grep owner
kafka_consumergroup_lag_sum{consumergroup="related-items-loader-us-KApp",owner="testrelated",topic="recsys-related-items-adamic_adar-yapocl-v1"} 0
kafka_consumergroup_lag_sum{consumergroup="related-items-loader-us-KApp",owner="testrelated",topic="recsys-related-items-bm25-similarity-segundamanomx-v1"} 0
kafka_consumergroup_lag_sum{consumergroup="related-items-loader-us-KApp",owner="testrelated",topic="recsys-related-items-bm25-similarity-yapocl-v1"} 0
kafka_consumergroup_lag_sum{consumergroup="p10n-content-consumer-f3d18403-3524-408e-aca7-88f258f20b56",owner="testp10",topic="privacy-consent-subito"} 79204
kafka_consumergroup_lag_sum{consumergroup="p10n-content-consumer-fa397240-f05b-48cf-8e34-4c798547aae3",owner="testp10",topic="privacy-consent-subito"} 55084
kafka_consumergroup_lag_sum{consumergroup="p10n-content-consumer-fff84547-75a5-49e2-9d35-f7a009cc25b8",owner="testp10",topic="privacy-consent-subito"} 62386
```